### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,42 +6,42 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-DS3231 KEYWORD1
-DS1307 KEYWORD1
+DS3231	KEYWORD1
+DS1307	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin KEYWORD2
-setSecond KEYWORD2
-setMinute KEYWORD2
-setHour KEYWORD2
-setDay KEYWORD2
-setMonth KEYWORD2
-setYear KEYWORD2
-setWeek KEYWORD2
-setDate KEYWORD2
-setTime KEYWORD2
-setEpoch KEYWORD2
+begin	KEYWORD2
+setSecond	KEYWORD2
+setMinute	KEYWORD2
+setHour	KEYWORD2
+setDay	KEYWORD2
+setMonth	KEYWORD2
+setYear	KEYWORD2
+setWeek	KEYWORD2
+setDate	KEYWORD2
+setTime	KEYWORD2
+setEpoch	KEYWORD2
 
-getYear KEYWORD2
-getMonth KEYWORD2
-getDay KEYWORD2
-getSecond KEYWORD2
-getMinute KEYWORD2
-getHour KEYWORD2
+getYear	KEYWORD2
+getMonth	KEYWORD2
+getDay	KEYWORD2
+getSecond	KEYWORD2
+getMinute	KEYWORD2
+getHour	KEYWORD2
 
-getWeek KEYWORD2
+getWeek	KEYWORD2
 
-enableAlaram KEYWORD2
+enableAlaram	KEYWORD2
 
-lostPower KEYWORD2
-StartClock KEYWORD2
-getTemp KEYWORD2
+lostPower	KEYWORD2
+StartClock	KEYWORD2
+getTemp	KEYWORD2
 
-getRegister KEYWORD2
-setRegister KEYWORD2
+getRegister	KEYWORD2
+setRegister	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords