### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -9,7 +9,7 @@
 DS3231	KEYWORD1
 DS1307	KEYWORD1
 PCF8563	KEYWORD1
-RTC KEYWORD1
+RTC	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -47,7 +47,7 @@ getWeek	KEYWORD2
 getMonth	KEYWORD2
 getYear	KEYWORD2
 
-getTemp KEYWORD2
+getTemp	KEYWORD2
 
 setEpoch	KEYWORD2
 getEpoch	KEYWORD2
@@ -57,17 +57,17 @@ getEpoch	KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-CLOCK_H24   LITERAL1
-CLOCK_H12   LITERAL1
+CLOCK_H24	LITERAL1
+CLOCK_H12	LITERAL1
 
-HOUR_AM   LITERAL1
-HOUR_PM   LITERAL1
-HOUR_24   LITERAL1
+HOUR_AM	LITERAL1
+HOUR_PM	LITERAL1
+HOUR_24	LITERAL1
 
-SQW001Hz   LITERAL1
-SQW04kHz   LITERAL1
-SQW08kHz   LITERAL1
-SQW32kHz   LITERAL1
+SQW001Hz	LITERAL1
+SQW04kHz	LITERAL1
+SQW08kHz	LITERAL1
+SQW32kHz	LITERAL1
 
 ###################################################
 # https://www.arduino.cc/en/Hacking/LibraryTutorial


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords