### PR TITLE
Correct DS3231 century flag & generic Unix/Arduino epoch handling

### DIFF
--- a/src/DS3231.cpp
+++ b/src/DS3231.cpp
@@ -532,12 +532,13 @@ setDate
 -----------------------------------------------------------*/
 void DS3231::setDate(uint8_t day, uint8_t month, uint16_t year)
 {
+	uint8_t century = year / 100;
 	year = year % 100; //Converting to 2 Digit
 
 	Wire.beginTransmission(DS3231_ADDR);
 	Wire.write(0x04);
 	Wire.write(bin2bcd(day));
-	Wire.write(bin2bcd(month));
+	Wire.write(bin2bcd(month) | (century >= 20 ? 128 : 0));
 	Wire.write(bin2bcd(year));
 	Wire.endTransmission();
 }

--- a/src/DS3231.cpp
+++ b/src/DS3231.cpp
@@ -532,7 +532,12 @@ setDate
 -----------------------------------------------------------*/
 void DS3231::setDate(uint8_t day, uint8_t month, uint16_t year)
 {
-	uint8_t century = year / 100;
+	uint8_t century;
+
+	// If year is 2 digits.
+	if(year < 100)
+		year = year + 2000;
+	century = year / 100;
 	year = year % 100; //Converting to 2 Digit
 
 	Wire.beginTransmission(DS3231_ADDR);
@@ -582,17 +587,22 @@ setEpoch()
 https://en.wikipedia.org/wiki/Epoch_(computing)
 -----------------------------------------------------------*/
 
-void DS3231::setEpoch(time_t epoch)
+void DS3231::setEpoch(time_t epoch, bool is_unix_epoch=true)
 {
 	uint8_t h_mode, data, century;
 	uint16_t year;
 	struct tm epoch_tm, *ptr_epoch_tm;
 
+	// adjust UNIX epoch to ARDUINO epoch, otherwise `tm` struct
+	// is one year and one (leap) day off.
+	if (is_unix_epoch)
+		epoch = epoch - UNIX_OFFSET;
+
 	ptr_epoch_tm = gmtime(&epoch);
 	epoch_tm = *ptr_epoch_tm;
 
-	century = (epoch_tm.tm_year + 1870) / 100;	// Find Century 
-	year = (epoch_tm.tm_year + 1870) % 100;		//Converting to 2 Digit
+	century = (epoch_tm.tm_year + 1900) / 100;	// Find Century 
+	year = (epoch_tm.tm_year + 1900) % 100;		//Converting to 2 Digit
 
 
 	Wire.beginTransmission(DS3231_ADDR);
@@ -687,7 +697,7 @@ void DS3231::setEpoch(time_t epoch)
 /*-----------------------------------------------------------
 getEpoch()
 -----------------------------------------------------------*/
-time_t DS3231::getEpoch()
+time_t DS3231::getEpoch(bool as_unix_epoch=true)
 {
 	uint8_t century_bit;
 	uint16_t century;
@@ -720,6 +730,8 @@ time_t DS3231::getEpoch()
 	epoch_tm.tm_year = epoch_tm.tm_year + century - 1870;
 
 	epoch = mktime(&epoch_tm);
+	if(as_unix_epoch)
+		epoch += UNIX_OFFSET;
 	return (epoch);
 }
 

--- a/src/RTC.h
+++ b/src/RTC.h
@@ -93,8 +93,8 @@ class DS1307
         uint8_t getMonth();
         uint16_t getYear();
 
-        void setEpoch(time_t epoch);
-        time_t getEpoch();
+        void setEpoch(time_t epoch, bool is_unix_epoch=true);
+        time_t getEpoch(bool as_unix_epoch=true);
 
         void setOutPin(uint8_t mode);
         bool isOutPinEnabled();
@@ -151,8 +151,8 @@ class DS3231 {
 		void setDate(uint8_t day, uint8_t month, uint16_t year);
 		void setTime(uint8_t hour, uint8_t minute, uint8_t second);
 
-		void setEpoch(time_t epoch);
-		time_t getEpoch();
+		void setEpoch(time_t epoch, bool is_unix_epoch=true);
+		time_t getEpoch(bool as_unix_epoch=true);
 
 		void setDateTime(char* date, char* time);
 


### PR DESCRIPTION
The `setDate()` method of the DS3231 didn't set the century flag correctly. Also, handling for "two-digit" years for both DS1307 and DS3231 added. 

"Epochs" weren't handled correctly, as Arduino uses a year-2000 based epoch, Unix (more commonly used) 1970, which also adds another leap day. Now the correct offset is used and you can select whether to use Unix (default) or Arduino epoch.
